### PR TITLE
seed explicitly MersenneTwister(0)

### DIFF
--- a/src/state.jl
+++ b/src/state.jl
@@ -12,7 +12,7 @@ type State
   flag_quote_name::Bool
   flag_quote_code::Bool
   
-  State() = new(MersenneTwister(), Parameters(), Float32[], Int32[], Bool[],
+  State() = new(MersenneTwister(0), Parameters(), Float32[], Int32[], Bool[],
     Any[], Any[], Any[], Dict{Symbol, Function}(), Dict{Symbol, Any}(), false, false)
 end
 


### PR DESCRIPTION
The default constructor `MersenneTwister()` will be deprecated, cf. https://github.com/JuliaLang/julia/pull/16984#issuecomment-290914407.